### PR TITLE
Minimal working example to solve issue #1

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^bench\.csv$
 ^benchmark\.qmd$
 ^benchmark\.md$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 custom_files/
 README.html
+.Rproj.user

--- a/R/sources_to_targets.R
+++ b/R/sources_to_targets.R
@@ -1,0 +1,40 @@
+#' Get matrix of travel times & distances from Valhalla API
+#'
+#' @param from a tibble of source locations, with columns "lat" and "lon" for latitude and longitude.
+#' @param to a tibble of destinations, with columns "lat" and "lon" for latitude and longitude.
+#' @param costing A string specifying the costing model to use for route optimization. Default is "auto".
+#' @param directions_options A named list.
+#'   By default this is list(units = "km") specifying the units to use.
+#' @inheritParams vh_get
+#' @return A tibble of distances & times, with source and destination indices.
+#' @export
+#'
+#' @examples
+sources_to_targets = function(
+    from,
+    to,
+    costing = "pedestrian",
+    directions_options = list(units = "km"),
+    url = "http://localhost:8002",
+    ...
+) {
+  
+  params = list(
+    sources = 
+      purrr::map(seq_len(nrow(from)), function(x) list(lon=from[x,]$lon,lat=from[x,]$lat)),
+    targets = 
+      purrr::map(seq_len(nrow(to)), function(x) list(lon=to[x,]$lon,lat=to[x,]$lat)),
+    costing = costing,
+    directions_options = directions_options,
+    ...
+  )
+  json = vh_get(resource="sources_to_targets",
+                from, 
+                to,
+                costing, 
+                units,
+                url = url, 
+                params = params)
+  purrr::map_dfr(json$sources_to_targets, function(x) tibble::as_tibble(x[[1]]))
+}
+  


### PR DESCRIPTION
https://github.com/Robinlovelace/rvalhalla/issues/1

Creates new issues:

- `from` and `to` need the tidyselect magic in case we don't want to feed exactly cols "lat" and "lon".
- Roxygen skeleton wants an example
- Work out whether we're happy returning the indices of `from` and `to`, or whether we'd rather have columns `from.lat`, `from.lon`, `to.lat`, `to.lon`.